### PR TITLE
Option rework

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,7 +2,8 @@ parameters:
     level: 5
     paths:
         - src
-    excludePaths:
-        - src/DependencyInjection/Configuration.php
     fileExtensions:
         - php
+    ignoreErrors:
+        - "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:[a-zA-Z]+\\(\\)\\.$#"
+        - "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:[a-zA-Z]+\\(\\)\\.$#"

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,6 +2,12 @@
 
 namespace Mezcalito\ImgproxyBundle\DependencyInjection;
 
+use Mezcalito\ImgproxyBundle\Option\Enlarge;
+use Mezcalito\ImgproxyBundle\Option\Extend;
+use Mezcalito\ImgproxyBundle\Option\Height;
+use Mezcalito\ImgproxyBundle\Option\ResizingType;
+use Mezcalito\ImgproxyBundle\Option\Rotate;
+use Mezcalito\ImgproxyBundle\Option\Width;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -73,23 +79,12 @@ class Configuration implements ConfigurationInterface
                                             ->end()
                                         ->end()
                                     ->end()
-                                    ->arrayNode('rotate')
-                                        ->children()
-                                            ->enumNode('angle')
-                                                ->values([0, 90, 180, 270])
-                                            ->end()
-                                        ->end()
-                                    ->end()
-                                    ->arrayNode('height')
-                                        ->children()
-                                            ->integerNode('height')->min(0)->end()
-                                        ->end()
-                                    ->end()
-                                    ->arrayNode('width')
-                                        ->children()
-                                            ->integerNode('width')->min(0)->end()
-                                        ->end()
-                                    ->end()
+                                    ->append(ResizingType::getConfig())
+                                    ->append(Enlarge::getConfig())
+                                    ->append(Extend::getConfig())
+                                    ->append(Rotate::getConfig())
+                                    ->append(Width::getConfig())
+                                    ->append(Height::getConfig())
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Option/Enlarge.php
+++ b/src/Option/Enlarge.php
@@ -18,13 +18,6 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
 class Enlarge extends Option
 {
-    public function getParts(): array
-    {
-        return [
-            $this->params['enlarge'],
-        ];
-    }
-
     public static function getConfig(): NodeDefinition
     {
         $root = new NodeBuilder();

--- a/src/Option/Enlarge.php
+++ b/src/Option/Enlarge.php
@@ -13,12 +13,23 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
 class Enlarge extends Option
 {
     public function getParts(): array
     {
         return [
-            $this->params['enlarge'] ? 'true' : 'false',
+            $this->params['enlarge'],
         ];
+    }
+
+    public static function getConfig(): NodeDefinition
+    {
+        $root = new NodeBuilder();
+
+        return $root
+            ->booleanNode('enlarge');
     }
 }

--- a/src/Option/Extend.php
+++ b/src/Option/Extend.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
 class Extend extends Option
 {
     public function getParts(): array
@@ -25,5 +28,13 @@ class Extend extends Option
         }
 
         return $parts;
+    }
+
+    public static function getConfig(): NodeDefinition
+    {
+        $root = new NodeBuilder();
+
+        return $root
+            ->booleanNode('enlarge');
     }
 }

--- a/src/Option/Gravity.php
+++ b/src/Option/Gravity.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
 class Gravity extends Option
 {
     public function getParts(): array
@@ -20,7 +23,21 @@ class Gravity extends Option
         return [
             $this->params['type'],
             $this->params['x_offset'],
-            $this->params['x_offset'],
+            $this->params['y_offset'],
         ];
+    }
+
+    public static function getConfig(): NodeDefinition
+    {
+        $root = new NodeBuilder();
+
+        return $root
+            ->arrayNode('gravity')
+                ->children()
+                    ->enumNode('resizing_type')->values(['no', 'so', 'ea', 'we', 'noea', 'nowe', 'soea', 'sowe', 'ce'])->end()
+                    ->floatNode('x_offset')->min(0)->end()
+                    ->floatNode('y_offset')->min(0)->end()
+                ->end()
+            ->end();
     }
 }

--- a/src/Option/Height.php
+++ b/src/Option/Height.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
 class Height extends Option
 {
     public function getParts(): array
@@ -20,5 +23,13 @@ class Height extends Option
         return [
             $this->params['height'],
         ];
+    }
+
+    public static function getConfig(): NodeDefinition
+    {
+        $root = new NodeBuilder();
+
+        return $root
+            ->integerNode('height')->min(0);
     }
 }

--- a/src/Option/Height.php
+++ b/src/Option/Height.php
@@ -18,13 +18,6 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
 class Height extends Option
 {
-    public function getParts(): array
-    {
-        return [
-            $this->params['height'],
-        ];
-    }
-
     public static function getConfig(): NodeDefinition
     {
         $root = new NodeBuilder();

--- a/src/Option/Option.php
+++ b/src/Option/Option.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
-use function Symfony\Component\String\u;
-
 abstract class Option implements OptionInterface
 {
     public function __construct(
@@ -34,6 +32,6 @@ abstract class Option implements OptionInterface
         $fqcn = \explode('\\', static::class);
         $className = \array_pop($fqcn);
 
-        return u($className)->lower()->snake()->toString();
+        return \strtolower(\preg_replace('/(?<!^)[A-Z]/', '_$0', $className));
     }
 }

--- a/src/Option/Option.php
+++ b/src/Option/Option.php
@@ -20,11 +20,23 @@ abstract class Option implements OptionInterface
     ) {
     }
 
-    abstract public function getParts(): array;
+    public function getParts(): array
+    {
+        return $this->params;
+    }
 
     public function resolve(): string
     {
-        return \implode(':', [$this->getName(), ...$this->getParts()]);
+        $result = $this->getName();
+        foreach ($this->getParts() as $part) {
+            if (\is_bool($part)) {
+                $result .= ':'.($part ? 'true' : 'false');
+            } else {
+                $result .= ':'.$part;
+            }
+        }
+
+        return $result;
     }
 
     public function getName(): string

--- a/src/Option/OptionFactory.php
+++ b/src/Option/OptionFactory.php
@@ -15,11 +15,12 @@ namespace Mezcalito\ImgproxyBundle\Option;
 
 final class OptionFactory
 {
-    public static function fromName(string $optionName, array $optionParams): OptionInterface
+    public static function fromName(string $optionName, mixed $optionParams): OptionInterface
     {
         $className = \lcfirst(\str_replace(' ', '', \ucwords(\str_replace('_', ' ', $optionName))));
         $fqcn = '\\Mezcalito\\ImgproxyBundle\\Option\\'.$className;
+        $params = \is_array($optionParams) ? $optionParams : [$optionParams];
 
-        return new $fqcn($optionParams);
+        return new $fqcn($params);
     }
 }

--- a/src/Option/OptionFactory.php
+++ b/src/Option/OptionFactory.php
@@ -13,13 +13,12 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
-use function Symfony\Component\String\u;
-
 final class OptionFactory
 {
     public static function fromName(string $optionName, array $optionParams): OptionInterface
     {
-        $fqcn = '\\Mezcalito\\ImgproxyBundle\\Option\\'.u($optionName)->camel()->title()->toString();
+        $className = \lcfirst(\str_replace(' ', '', \ucwords(\str_replace('_', ' ', $optionName))));
+        $fqcn = '\\Mezcalito\\ImgproxyBundle\\Option\\'.$className;
 
         return new $fqcn($optionParams);
     }

--- a/src/Option/OptionInterface.php
+++ b/src/Option/OptionInterface.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
 interface OptionInterface
 {
     public function getName(): string;
+
+    public static function getConfig(): NodeDefinition;
 
     public function resolve(): string;
 }

--- a/src/Option/Resize.php
+++ b/src/Option/Resize.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
 class Resize extends Option
 {
     public function getParts(): array
@@ -40,5 +43,13 @@ class Resize extends Option
         }
 
         return $parts;
+    }
+
+    public static function getConfig(): NodeDefinition
+    {
+        $root = new NodeBuilder();
+
+        // TODO: manage meta options
+        return $root->end();
     }
 }

--- a/src/Option/ResizingType.php
+++ b/src/Option/ResizingType.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
 class ResizingType extends Option
 {
     public function getParts(): array
@@ -20,5 +23,13 @@ class ResizingType extends Option
         return [
             $this->params['resizing_type'],
         ];
+    }
+
+    public static function getConfig(): NodeDefinition
+    {
+        $root = new NodeBuilder();
+
+        return $root
+            ->enumNode('resizing_type')->values(['fit', 'fill', 'fill-down', 'force', 'auto']);
     }
 }

--- a/src/Option/ResizingType.php
+++ b/src/Option/ResizingType.php
@@ -18,13 +18,6 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
 class ResizingType extends Option
 {
-    public function getParts(): array
-    {
-        return [
-            $this->params['resizing_type'],
-        ];
-    }
-
     public static function getConfig(): NodeDefinition
     {
         $root = new NodeBuilder();

--- a/src/Option/Rotate.php
+++ b/src/Option/Rotate.php
@@ -13,16 +13,23 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
 class Rotate extends Option
 {
     public function getParts(): array
     {
-        $parts = [];
+        return [
+            $this->params['rotate'],
+        ];
+    }
 
-        if (\array_key_exists('angle', $this->params)) {
-            $parts['angle'] = $this->params['angle'];
-        }
+    public static function getConfig(): NodeDefinition
+    {
+        $root = new NodeBuilder();
 
-        return $parts;
+        return $root
+            ->enumNode('rotate')->values([0, 90, 180, 270]);
     }
 }

--- a/src/Option/Rotate.php
+++ b/src/Option/Rotate.php
@@ -18,13 +18,6 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
 class Rotate extends Option
 {
-    public function getParts(): array
-    {
-        return [
-            $this->params['rotate'],
-        ];
-    }
-
     public static function getConfig(): NodeDefinition
     {
         $root = new NodeBuilder();

--- a/src/Option/Width.php
+++ b/src/Option/Width.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Option;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
 class Width extends Option
 {
     public function getParts(): array
@@ -20,5 +23,13 @@ class Width extends Option
         return [
             $this->params['width'],
         ];
+    }
+
+    public static function getConfig(): NodeDefinition
+    {
+        $root = new NodeBuilder();
+
+        return $root
+            ->integerNode('width')->min(0);
     }
 }

--- a/src/Option/Width.php
+++ b/src/Option/Width.php
@@ -18,13 +18,6 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
 class Width extends Option
 {
-    public function getParts(): array
-    {
-        return [
-            $this->params['width'],
-        ];
-    }
-
     public static function getConfig(): NodeDefinition
     {
         $root = new NodeBuilder();

--- a/src/Test/OptionTestCase.php
+++ b/src/Test/OptionTestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Mezcalito ImgproxyBundle.
+ *
+ * (c) Mezcalito <dev@mezcalito.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mezcalito\ImgproxyBundle\Test;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+abstract class OptionTestCase extends TestCase
+{
+    abstract public static function getOptionClass(): string;
+
+    abstract public static function getOptionTests(): iterable;
+
+    #[DataProvider('getOptionTests')]
+    public function testResolve(array $params, string $result): void
+    {
+        $option = (new (static::getOptionClass())($params));
+        $this->assertEquals($result, $option->resolve());
+    }
+}

--- a/tests/Option/EnlargeTest.php
+++ b/tests/Option/EnlargeTest.php
@@ -14,23 +14,16 @@ declare(strict_types=1);
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
 use Mezcalito\ImgproxyBundle\Option\Enlarge;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Mezcalito\ImgproxyBundle\Test\OptionTestCase;
 
-class EnlargeTest extends TestCase
+class EnlargeTest extends OptionTestCase
 {
-    public function testGetName(): void
+    public static function getOptionClass(): string
     {
-        $this->assertEquals('enlarge', (new Enlarge([]))->getName());
+        return Enlarge::class;
     }
 
-    #[DataProvider('options')]
-    public function testResolve(array $params, string $result): void
-    {
-        $this->assertEquals($result, (new Enlarge($params))->resolve());
-    }
-
-    public static function options(): iterable
+    public static function getOptionTests(): iterable
     {
         yield [
             'params' => ['enlarge' => false],

--- a/tests/Option/ExtendTest.php
+++ b/tests/Option/ExtendTest.php
@@ -14,23 +14,16 @@ declare(strict_types=1);
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
 use Mezcalito\ImgproxyBundle\Option\Extend;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Mezcalito\ImgproxyBundle\Test\OptionTestCase;
 
-class ExtendTest extends TestCase
+class ExtendTest extends OptionTestCase
 {
-    public function testGetName(): void
+    public static function getOptionClass(): string
     {
-        $this->assertEquals('extend', (new Extend(['extend' => true]))->getName());
+        return Extend::class;
     }
 
-    #[DataProvider('options')]
-    public function testResolve(array $params, string $result): void
-    {
-        $this->assertEquals($result, (new Extend($params))->resolve());
-    }
-
-    public static function options(): iterable
+    public static function getOptionTests(): iterable
     {
         yield [
             'params' => ['extend' => false, 'gravity' => ['type' => 'ce', 'x_offset' => 0, 'y_offset' => 0]],

--- a/tests/Option/GravityTest.php
+++ b/tests/Option/GravityTest.php
@@ -14,23 +14,16 @@ declare(strict_types=1);
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
 use Mezcalito\ImgproxyBundle\Option\Gravity;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Mezcalito\ImgproxyBundle\Test\OptionTestCase;
 
-class GravityTest extends TestCase
+class GravityTest extends OptionTestCase
 {
-    public function testGetName(): void
+    public static function getOptionClass(): string
     {
-        $this->assertEquals('gravity', (new Gravity(['type' => 'ce', 'x_offset' => 0, 'y_offset' => 0]))->getName());
+        return Gravity::class;
     }
 
-    #[DataProvider('options')]
-    public function testResolve(array $params, string $result): void
-    {
-        $this->assertEquals($result, (new Gravity($params))->resolve());
-    }
-
-    public static function options(): iterable
+    public static function getOptionTests(): iterable
     {
         yield [
             'params' => ['type' => 'ce', 'x_offset' => 0, 'y_offset' => 0],

--- a/tests/Option/HeightTest.php
+++ b/tests/Option/HeightTest.php
@@ -14,23 +14,16 @@ declare(strict_types=1);
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
 use Mezcalito\ImgproxyBundle\Option\Height;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Mezcalito\ImgproxyBundle\Test\OptionTestCase;
 
-class HeightTest extends TestCase
+class HeightTest extends OptionTestCase
 {
-    public function testGetName(): void
+    public static function getOptionClass(): string
     {
-        $this->assertEquals('height', (new Height([]))->getName());
+        return Height::class;
     }
 
-    #[DataProvider('options')]
-    public function testResolve(array $params, string $result): void
-    {
-        $this->assertEquals($result, (new Height($params))->resolve());
-    }
-
-    public static function options(): iterable
+    public static function getOptionTests(): iterable
     {
         yield [
             'params' => ['height' => '42'],

--- a/tests/Option/HeightTest.php
+++ b/tests/Option/HeightTest.php
@@ -13,28 +13,28 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
-use Mezcalito\ImgproxyBundle\Option\Enlarge;
+use Mezcalito\ImgproxyBundle\Option\Height;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class EnlargeTest extends TestCase
+class HeightTest extends TestCase
 {
     public function testGetName(): void
     {
-        $this->assertEquals('enlarge', (new Enlarge([]))->getName());
+        $this->assertEquals('height', (new Height([]))->getName());
     }
 
     #[DataProvider('options')]
     public function testResolve(array $params, string $result): void
     {
-        $this->assertEquals($result, (new Enlarge($params))->resolve());
+        $this->assertEquals($result, (new Height($params))->resolve());
     }
 
     public static function options(): iterable
     {
         yield [
-            'params' => ['enlarge' => false],
-            'result' => 'enlarge:false',
+            'params' => ['height' => '42'],
+            'result' => 'height:42',
         ];
     }
 }

--- a/tests/Option/ResizeTest.php
+++ b/tests/Option/ResizeTest.php
@@ -14,23 +14,16 @@ declare(strict_types=1);
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
 use Mezcalito\ImgproxyBundle\Option\Resize;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Mezcalito\ImgproxyBundle\Test\OptionTestCase;
 
-class ResizeTest extends TestCase
+class ResizeTest extends OptionTestCase
 {
-    public function testGetName(): void
+    public static function getOptionClass(): string
     {
-        $this->assertEquals('resize', (new Resize(['resizing_type' => 'fit', 'width' => 150, 'height' => 75]))->getName());
+        return Resize::class;
     }
 
-    #[DataProvider('options')]
-    public function testResolve(array $params, string $result): void
-    {
-        $this->assertEquals($result, (new Resize($params))->resolve());
-    }
-
-    public static function options(): iterable
+    public static function getOptionTests(): iterable
     {
         yield [
             'params' => [

--- a/tests/Option/ResizingTypeTest.php
+++ b/tests/Option/ResizingTypeTest.php
@@ -13,28 +13,28 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
-use Mezcalito\ImgproxyBundle\Option\Enlarge;
+use Mezcalito\ImgproxyBundle\Option\ResizingType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class EnlargeTest extends TestCase
+class ResizingTypeTest extends TestCase
 {
     public function testGetName(): void
     {
-        $this->assertEquals('enlarge', (new Enlarge([]))->getName());
+        $this->assertEquals('resizing_type', (new ResizingType([]))->getName());
     }
 
     #[DataProvider('options')]
     public function testResolve(array $params, string $result): void
     {
-        $this->assertEquals($result, (new Enlarge($params))->resolve());
+        $this->assertEquals($result, (new ResizingType($params))->resolve());
     }
 
     public static function options(): iterable
     {
         yield [
-            'params' => ['enlarge' => false],
-            'result' => 'enlarge:false',
+            'params' => ['resizing_type' => 'fit'],
+            'result' => 'resizing_type:fit',
         ];
     }
 }

--- a/tests/Option/ResizingTypeTest.php
+++ b/tests/Option/ResizingTypeTest.php
@@ -14,23 +14,16 @@ declare(strict_types=1);
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
 use Mezcalito\ImgproxyBundle\Option\ResizingType;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Mezcalito\ImgproxyBundle\Test\OptionTestCase;
 
-class ResizingTypeTest extends TestCase
+class ResizingTypeTest extends OptionTestCase
 {
-    public function testGetName(): void
+    public static function getOptionClass(): string
     {
-        $this->assertEquals('resizing_type', (new ResizingType([]))->getName());
+        return ResizingType::class;
     }
 
-    #[DataProvider('options')]
-    public function testResolve(array $params, string $result): void
-    {
-        $this->assertEquals($result, (new ResizingType($params))->resolve());
-    }
-
-    public static function options(): iterable
+    public static function getOptionTests(): iterable
     {
         yield [
             'params' => ['resizing_type' => 'fit'],

--- a/tests/Option/RotateTest.php
+++ b/tests/Option/RotateTest.php
@@ -14,28 +14,19 @@ declare(strict_types=1);
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
 use Mezcalito\ImgproxyBundle\Option\Rotate;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Mezcalito\ImgproxyBundle\Test\OptionTestCase;
 
-class RotateTest extends TestCase
+class RotateTest extends OptionTestCase
 {
-    public function testGetName(): void
+    public static function getOptionClass(): string
     {
-        $this->assertEquals('rotate', (new Rotate(['angle' => 90]))->getName());
+        return Rotate::class;
     }
 
-    #[DataProvider('options')]
-    public function testResolve(array $params, string $result): void
-    {
-        $this->assertEquals($result, (new Rotate($params))->resolve());
-    }
-
-    public static function options(): iterable
+    public static function getOptionTests(): iterable
     {
         yield [
-            'params' => [
-                'angle' => 90,
-            ],
+            'params' => ['rotate' => 90],
             'result' => 'rotate:90',
         ];
     }

--- a/tests/Option/WidthTest.php
+++ b/tests/Option/WidthTest.php
@@ -14,23 +14,16 @@ declare(strict_types=1);
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
 use Mezcalito\ImgproxyBundle\Option\Width;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
+use Mezcalito\ImgproxyBundle\Test\OptionTestCase;
 
-class WidthTest extends TestCase
+class WidthTest extends OptionTestCase
 {
-    public function testGetName(): void
+    public static function getOptionClass(): string
     {
-        $this->assertEquals('width', (new Width([]))->getName());
+        return Width::class;
     }
 
-    #[DataProvider('options')]
-    public function testResolve(array $params, string $result): void
-    {
-        $this->assertEquals($result, (new Width($params))->resolve());
-    }
-
-    public static function options(): iterable
+    public static function getOptionTests(): iterable
     {
         yield [
             'params' => ['width' => '42'],

--- a/tests/Option/WidthTest.php
+++ b/tests/Option/WidthTest.php
@@ -13,28 +13,28 @@ declare(strict_types=1);
 
 namespace Mezcalito\ImgproxyBundle\Tests\Option;
 
-use Mezcalito\ImgproxyBundle\Option\Enlarge;
+use Mezcalito\ImgproxyBundle\Option\Width;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class EnlargeTest extends TestCase
+class WidthTest extends TestCase
 {
     public function testGetName(): void
     {
-        $this->assertEquals('enlarge', (new Enlarge([]))->getName());
+        $this->assertEquals('width', (new Width([]))->getName());
     }
 
     #[DataProvider('options')]
     public function testResolve(array $params, string $result): void
     {
-        $this->assertEquals($result, (new Enlarge($params))->resolve());
+        $this->assertEquals($result, (new Width($params))->resolve());
     }
 
     public static function options(): iterable
     {
         yield [
-            'params' => ['enlarge' => false],
-            'result' => 'enlarge:false',
+            'params' => ['width' => '42'],
+            'result' => 'width:42',
         ];
     }
 }

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -149,7 +149,7 @@ class ResolverTest extends TestCase
                     'format' => 'webp',
                     'options' => [
                         'resize' => ['width' => 150, 'height' => 75, 'enlarge' => true],
-                        'rotate' => ['angle' => 90],
+                        'rotate' => 90,
                     ],
                 ],
                 'encoded_thumbnail' => [
@@ -157,7 +157,7 @@ class ResolverTest extends TestCase
                     'encode' => true,
                     'options' => [
                         'resize' => ['width' => 150, 'height' => 75, 'enlarge' => true],
-                        'rotate' => ['angle' => 270],
+                        'rotate' => 270,
                     ],
                 ],
             ],


### PR DESCRIPTION
This is the rework of the option class. The main idea is to have one class per option, and that each class carries the URL construction and Symfony YAML configuration.

This is a work in progress. I think the simple options (height, width, rotate,...) are fine as I've done them, but there's still the imgproxy “meta options” (e.g. resize). I'd like these “meta options” to be based on the simple options to avoid duplicating code, but I haven't figured out how to do it properly yet.

If anyone has any ideas, I'd love to hear them.