### PR TITLE
Fix class casing regression after removing Symfony String component

### DIFF
--- a/src/Option/OptionFactory.php
+++ b/src/Option/OptionFactory.php
@@ -17,7 +17,7 @@ final class OptionFactory
 {
     public static function fromName(string $optionName, array $optionParams): OptionInterface
     {
-        $className = \lcfirst(\str_replace(' ', '', \ucwords(\str_replace('_', ' ', $optionName))));
+        $className = \ucfirst(\str_replace(' ', '', \ucwords(\str_replace('_', ' ', $optionName))));
         $fqcn = '\\Mezcalito\\ImgproxyBundle\\Option\\'.$className;
 
         return new $fqcn($optionParams);

--- a/tests/Option/OptionFactoryTest.php
+++ b/tests/Option/OptionFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Mezcalito ImgproxyBundle.
+ *
+ * (c) Mezcalito <dev@mezcalito.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mezcalito\ImgproxyBundle\Tests\Option;
+
+use Mezcalito\ImgproxyBundle\Option\OptionFactory;
+use Mezcalito\ImgproxyBundle\Option\Resize;
+use PHPUnit\Framework\TestCase;
+
+class OptionFactoryTest extends TestCase
+{
+    public function testGenerateOptionFromValidName(): void
+    {
+        $result = OptionFactory::fromName('resize', []);
+
+        $this->assertInstanceOf(Resize::class, $result);
+    }
+
+    public function testGenerateOptionFromInvalidName(): void
+    {
+        $this->expectException(\Throwable::class);
+
+        OptionFactory::fromName('invalid', []);
+    }
+}


### PR DESCRIPTION
hi,
i found a small bug in the OptionFactory class.

The issue was introduced when switching away from the Symfony String component (https://github.com/Mezcalito/imgproxy-bundle/commit/1635a1cffb8406cccc8c4e9493ca90819038accd). 
The replacement logic incorrectly used lcfirst, causing autoloader failures.

```
Error: Class "\Mezcalito\ImgproxyBundle\Option\resize" not found
/[...]/imgproxy-bundle/src/Option/OptionFactory.php:23
/[...]/imgproxy-bundle/tests/Option/OptionFactoryTest.php:24
```

I changed it to ucfirst so the generated class names match the actual classes (e.g., Resize).
I also added two small regression tests.

