### PR TITLE
Allow empty or null options in presets

### DIFF
--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -52,7 +52,8 @@ class Resolver
         }
 
         $options = [];
-        foreach ($preset['options'] as $optionName => $optionParams) {
+        $presetOptions = $preset['options'] ?? [];
+        foreach ($presetOptions as $optionName => $optionParams) {
             $option = OptionFactory::fromName($optionName, $optionParams);
             $options[] = $option->resolve();
         }
@@ -65,7 +66,7 @@ class Resolver
             $source = Encoder::encode($src, true);
         }
 
-        $path = '/'.$options.'/'.$source.$separator.$preset['format'];
+        $path = '/'.($options ? $options.'/' : '').$source.$separator.$preset['format'];
         $signature = $this->signer->generateSignature($path);
 
         return $this->host.'/'.$signature.$path;

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -76,6 +76,14 @@ class ResolverTest extends TestCase
         $this->resolver->getBrowserPath('https://fakeimg.pl/350x200/?text=Mezcalito', 'test');
     }
 
+    #[DataProvider('localUrlFalsyOptions')]
+    public function testCreateLocalUrlWithFalsyOption(string $src, string $filter, string $result): void
+    {
+        $this->addingContainer();
+
+        $this->assertEquals($result, $this->resolver->getBrowserPath($src, $filter));
+    }
+
     public static function plainUrl(): iterable
     {
         yield [
@@ -122,6 +130,25 @@ class ResolverTest extends TestCase
         ];
     }
 
+    public static function localUrlFalsyOptions(): iterable
+    {
+        yield [
+            'src' => 'image.png',
+            'filter' => 'no_options',
+            'result' => 'http://localhost:8080/X_PYvMBPKiTcVblydcE_wagAk_jwFeHOM3JoHyiZ5Gk/plain/localhostimage.png@webp',
+        ];
+        yield [
+            'src' => 'image.png',
+            'filter' => 'empty_options',
+            'result' => 'http://localhost:8080/X_PYvMBPKiTcVblydcE_wagAk_jwFeHOM3JoHyiZ5Gk/plain/localhostimage.png@webp',
+        ];
+        yield [
+            'src' => 'image.png',
+            'filter' => 'null_options',
+            'result' => 'http://localhost:8080/X_PYvMBPKiTcVblydcE_wagAk_jwFeHOM3JoHyiZ5Gk/plain/localhostimage.png@webp',
+        ];
+    }
+
     private function addingContainer(bool $withMediaUrl = false, bool $withRequest = true): void
     {
         $container = $this->createContainer($withMediaUrl);
@@ -159,6 +186,17 @@ class ResolverTest extends TestCase
                         'resize' => ['width' => 150, 'height' => 75, 'enlarge' => true],
                         'rotate' => ['angle' => 270],
                     ],
+                ],
+                'no_options' => [
+                    'format' => 'webp',
+                ],
+                'empty_options' => [
+                    'format' => 'webp',
+                    'options' => [],
+                ],
+                'null_options' => [
+                    'format' => 'webp',
+                    'options' => null,
                 ],
             ],
         ];


### PR DESCRIPTION
## Description
Allows presets to be defined without options or with empty/null options values, providing more flexibility in preset configuration.

## Changes
- `Resolver` handles falsy option values by normalizing them to empty arrays

## Testing
Added comprehensive tests covering three scenarios:
- Preset without `options` key
- Preset with empty `options` array
- Preset with `null` options value

All three cases produce identical results, ensuring consistent behavior regardless of how "no options" is expressed.
